### PR TITLE
Added swe_get_library_path() mapping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IntelliJ / PhpStorm project directory.
+.idea

--- a/php_sweph.h
+++ b/php_sweph.h
@@ -49,6 +49,7 @@ PHP_FUNCTION(swe_get_ayanamsa);
 PHP_FUNCTION(swe_get_ayanamsa_ut);
 PHP_FUNCTION(swe_get_ayanamsa_name);
 PHP_FUNCTION(swe_version);
+PHP_FUNCTION(swe_get_library_path);
 
 /**************************** 
  * exports from swedate.c 

--- a/sweph.c
+++ b/sweph.c
@@ -50,6 +50,7 @@ zend_function_entry sweph_functions[] = {
 	PHP_FE(swe_get_ayanamsa_ut, NULL)
 	PHP_FE(swe_get_ayanamsa_name, NULL)
 	PHP_FE(swe_version, NULL)
+	PHP_FE(swe_get_library_path, NULL)
 
 	/**************************** 
 	 * exports from swedate.c 
@@ -695,6 +696,15 @@ PHP_FUNCTION(swe_version)
 	if(ZEND_NUM_ARGS() != 0) WRONG_PARAM_COUNT;
 
 	RETURN_STRING(swe_version(name));
+}
+
+PHP_FUNCTION(swe_get_library_path)
+{
+    char path[AS_MAXCH];
+
+    if (ZEND_NUM_ARGS() != 0) WRONG_PARAM_COUNT;
+
+    RETURN_STRING(swe_get_library_path(path));
 }
 
 /**************************** 


### PR DESCRIPTION
This method returns the path where the executable resides.

Ex.

```
$ php -a
php > echo swe_get_library_path();
/usr/lib/php/20170718/sweph.so
php > exit
$
```


