### PR TITLE
Changed arg count to 4.

### DIFF
--- a/sweph.c
+++ b/sweph.c
@@ -1770,7 +1770,7 @@ PHP_FUNCTION(swe_rise_trans_true_hor)
 PHP_FUNCTION(swe_nod_aps)
 {
 	char *arg = NULL;
-	int arg_len, rc, ipl, iflag, method;
+	int rc, ipl, iflag, method;
 	double tjd_et, xnasc[6], xndsc[6], xperi[6], xaphe[6];
 	char serr[AS_MAXCH]; 
 	int i;
@@ -1781,8 +1781,7 @@ PHP_FUNCTION(swe_nod_aps)
 	fprintf(stderr,"swe_nod_aps: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_et, ipl, iflag, method);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
-			&tjd_et, &ipl, &iflag, &method,
-			&arg_len) == FAILURE) {
+			&tjd_et, &ipl, &iflag, &method) == FAILURE) {
 		return;
 	}
 
@@ -1825,7 +1824,7 @@ PHP_FUNCTION(swe_nod_aps)
 PHP_FUNCTION(swe_nod_aps_ut)
 {
 	char *arg = NULL;
-	int arg_len, rc, ipl, iflag, method;
+	int rc, ipl, iflag, method;
 	double tjd_ut, xnasc[6], xndsc[6], xperi[6], xaphe[6];
 	char serr[AS_MAXCH]; 
 	int i;
@@ -1836,8 +1835,7 @@ PHP_FUNCTION(swe_nod_aps_ut)
     fprintf(stderr,"swe_nod_aps_ut: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_ut, ipl, iflag, method);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
-			&tjd_ut, &ipl, &iflag, &method,
-			&arg_len) == FAILURE) {
+			&tjd_ut, &ipl, &iflag, &method) == FAILURE) {
 		return;
 	}
 

--- a/sweph.c
+++ b/sweph.c
@@ -1778,12 +1778,17 @@ PHP_FUNCTION(swe_nod_aps)
 
 	if(ZEND_NUM_ARGS() != 4) WRONG_PARAM_COUNT;
 
+	fprintf(stderr,"swe_nod_aps: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_et, ipl, iflag, method);
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
 			&tjd_et, &ipl, &iflag, &method,
 			&arg_len) == FAILURE) {
 		return;
 	}
-	rc = swe_nod_aps_ut(tjd_et, ipl, iflag, method, xnasc, xndsc, xperi, xaphe, serr);
+
+	fprintf(stderr,"swe_nod_aps: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_et, ipl, iflag, method);
+
+	rc = swe_nod_aps(tjd_et, ipl, iflag, method, xnasc, xndsc, xperi, xaphe, serr);
 
 	array_init(return_value);
 	add_assoc_long(return_value, "retflag", rc);
@@ -1882,10 +1887,14 @@ PHP_FUNCTION(swe_deltat)
 	
 	if(ZEND_NUM_ARGS() != 1) WRONG_PARAM_COUNT;
 
+	fprintf(stderr,"swe_deltat: tj=%lf\n", tjd_ut);
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d",
 			&tjd_ut) == FAILURE) {
 		return;
 	}
+
+	fprintf(stderr,"swe_deltat: tj=%lf\n", tjd_ut);
 
 	RETURN_DOUBLE(swe_deltat(tjd_ut));
 }

--- a/sweph.c
+++ b/sweph.c
@@ -1776,7 +1776,7 @@ PHP_FUNCTION(swe_nod_aps)
 	int i;
 	zval xnasc_arr, xndsc_arr, xperi_arr, xaphe_arr;
 
-	if(ZEND_NUM_ARGS() != 10) WRONG_PARAM_COUNT;
+	if(ZEND_NUM_ARGS() != 4) WRONG_PARAM_COUNT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
 			&tjd_et, &ipl, &iflag, &method,
@@ -1826,7 +1826,7 @@ PHP_FUNCTION(swe_nod_aps_ut)
 	int i;
 	zval xnasc_arr, xndsc_arr, xperi_arr, xaphe_arr;
 
-	if(ZEND_NUM_ARGS() != 10) WRONG_PARAM_COUNT;
+	if(ZEND_NUM_ARGS() != 4) WRONG_PARAM_COUNT;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
 			&tjd_ut, &ipl, &iflag, &method,

--- a/sweph.c
+++ b/sweph.c
@@ -1828,11 +1828,16 @@ PHP_FUNCTION(swe_nod_aps_ut)
 
 	if(ZEND_NUM_ARGS() != 4) WRONG_PARAM_COUNT;
 
+    fprintf(stderr,"swe_nod_aps_ut: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_ut, ipl, iflag, method);
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dlll",
 			&tjd_ut, &ipl, &iflag, &method,
 			&arg_len) == FAILURE) {
 		return;
 	}
+
+    fprintf(stderr,"swe_nod_aps_ut: tj=%lf, ipl=%ld, iflag=%ld, mthod=%ld\n", tjd_ut, ipl, iflag, method);
+
 	rc = swe_nod_aps_ut(tjd_ut, ipl, iflag, method, xnasc, xndsc, xperi, xaphe, serr);
 
 	array_init(return_value);


### PR DESCRIPTION
Closes #3 

This is working for me, but I haven't tested extensively yet. I am getting some different results running `swe_nod_aps_ut()` vs. what `swetest` provides, but I may not be comparing apples-to-apples. I'm still getting used to this API.
