### PR TITLE
Calling correct SE method.

### DIFF
--- a/sweph.c
+++ b/sweph.c
@@ -1784,7 +1784,7 @@ PHP_FUNCTION(swe_nod_aps)
 			&arg_len) == FAILURE) {
 		return;
 	}
-	rc = swe_nod_aps_ut(tjd_et, ipl, iflag, method, xnasc, xndsc, xperi, xaphe, serr);
+	rc = swe_nod_aps(tjd_et, ipl, iflag, method, xnasc, xndsc, xperi, xaphe, serr);
 
 	array_init(return_value);
 	add_assoc_long(return_value, "retflag", rc);


### PR DESCRIPTION
It was pointed out to me that `swe_nod_aps()` was calling the incorrect method under the hood (the `_ut()` one). Both have the same method signature, so no other changes should be needed:

https://www.astro.com/swisseph/swephprg.htm#_Toc505244849
