### PR TITLE
Streamline format functions in tests.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,29 @@
+name: run-tests
+
+on: [push]
+
+jobs:
+  make-test:
+    strategy:
+      matrix:
+        php-versions: ['7.3']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository.
+        uses: actions/checkout@v2
+
+      - name: Install php-dev.
+        run: sudo apt install php-dev
+
+      - name: Build Extension.
+        run: |
+          phpize
+          ./configure
+          make
+          make install
+          echo "extension=swephp.so" > /usr/local/etc/php/conf.d/swephp.ini
+
+      - name: Run Tests.
+        run: yes n | make test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   make-test:
     strategy:
       matrix:
-        php: ['7.3']
+        php: ['7.3', '7.4']
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   make-test:
     strategy:
       matrix:
-        php-versions: ['7.3']
+        php: ['7.3']
 
     runs-on: ubuntu-latest
 
@@ -14,8 +14,15 @@ jobs:
       - name: Checkout Repository.
         uses: actions/checkout@v2
 
-      - name: Install php-dev.
-        run: sudo apt install php-dev
+      - name: Install php${{ matrix.php }}-dev.
+        run: |
+          sudo apt install software-properties-common
+          sudo add-apt-repository ppa:ondrej/php
+          sudo apt update
+          sudo apt install php${{ matrix.php }}-dev
+          sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+          sudo update-alternatives --set phpize /usr/bin/phpize${{ matrix.php }}
+          sudo update-alternatives --set php-config /usr/bin/php-config${{ matrix.php }}
 
       - name: Build Extension.
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,8 +29,7 @@ jobs:
           phpize
           ./configure
           make
-          make install
-          echo "extension=swephp.so" > /usr/local/etc/php/conf.d/swephp.ini
+          sudo make install
 
       - name: Run Tests.
         run: yes n | make test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
   make-test:
     strategy:
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4']
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ libtool
 missing
 mk*
 run-test*
+!.github/workflows/run-tests.yml
 !config.m4
 config*
 install-sh

--- a/tests/swe_azalt_refrac.phpt
+++ b/tests/swe_azalt_refrac.phpt
@@ -8,202 +8,340 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
+
 $geo = array(12.1, 49.0, 330);
 $tjd_ut = 2454503.06;
 $atpress = 0;
 $atemp = 30;
+
 for ($p = SE_SUN; $p <= SE_PLUTO; $p++) {
   $pnam = swe_get_planet_name($p);
   $rv = swe_calc_ut($tjd_ut, $p, SEFLG_SWIEPH);
   $xin0 = $rv[0];
   $xin1 = $rv[1];
+
   echo "swe_azalt($tjd_ut, SE_ECL2HOR, $geo[0], $geo[1], $geo[2], $atpress, $atemp, $xin0, $xin1)\n";
   $rv = swe_azalt($tjd_ut, SE_ECL2HOR, $geo[0], $geo[1], $geo[2], $atpress, $atemp, $xin0, $xin1);
   printf("planet %s\tlon=%f\tlat=%f\nhorizon coordinates\n", $pnam, $xin0, $xin1);
   $azi = $rv[0];
   $talt = $rv[1];
-  print_array( $rv, 3, 'xaz');
+  var_dump(Format::round($rv));
+
   echo "swe_azalt_rev($tjd_ut, SE_HOR2ECL, $geo[0], $geo[1], $geo[2], $azi, $talt)\n";
   $rv = swe_azalt_rev($tjd_ut, SE_HOR2ECL, $geo[0], $geo[1], $geo[2], $azi, $talt);
   printf("converted back\tlon=%f\tlat=%f\n", $rv[0], $rv[1]);
+
   echo "swe_refrac($talt, $atpress, $atemp, SE_TRUE_TO_APP)\n";
   $appalt = swe_refrac($talt, $atpress, $atemp, SE_TRUE_TO_APP);
   printf("app. alt = %f\n", $appalt);
+
   echo "swe_refrac_extended($talt, $geo[2], $atpress, $atemp, 10.0, SE_TRUE_TO_APP)\n";
-  $rv  = swe_refrac_extended($talt, $geo[2], $atpress, $atemp, 10.0, SE_TRUE_TO_APP);
-  print_array( $rv, 4, 'rv');
+  $rv = swe_refrac_extended($talt, $geo[2], $atpress, $atemp, 10.0, SE_TRUE_TO_APP);
+  var_dump(Format::round($rv));
 }
 
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
-
-function print_array($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++)
-   printf( "%s[%d] = %f\n", $name, $i, $arr[$i]);;
-}
-function print_array_t($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++) {
-   printf( "%s[%d] = %f %s\n", $name, $i, $arr[$i], print_date($arr[$i]));;
-  }
-}
 ?>
 --EXPECT--
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 317.13145055883, -8.1708335644352E-5)
 planet Sun	lon=317.131451	lat=-0.000082
 horizon coordinates
-xaz[0] = 31.000508
-xaz[1] = 19.979725
-xaz[2] = 20.019722
+array(3) {
+  [0]=>
+  float(31.000508)
+  [1]=>
+  float(19.979725)
+  [2]=>
+  float(20.019722)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 31.000507789831, 19.97972538002)
 converted back	lon=317.131451	lat=-0.000082
 swe_refrac(19.97972538002, 0, 30, SE_TRUE_TO_APP)
 app. alt = 19.979725
 swe_refrac_extended(19.97972538002, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 19.979725
-rv[1] = 19.976139
-rv[2] = -0.003587
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(19)
+  [0]=>
+  float(19.979725)
+  [1]=>
+  float(19.976139)
+  [2]=>
+  float(-0.003587)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(19)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 309.8883982075, -1.6164161204145)
 planet Moon	lon=309.888398	lat=-1.616416
 horizon coordinates
-xaz[0] = 35.830421
-xaz[1] = 14.168707
-xaz[2] = 14.225327
+array(3) {
+  [0]=>
+  float(35.830421)
+  [1]=>
+  float(14.168707)
+  [2]=>
+  float(14.225327)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 35.830421428922, 14.168707435917)
 converted back	lon=309.888398	lat=-1.616416
 swe_refrac(14.168707435917, 0, 30, SE_TRUE_TO_APP)
 app. alt = 14.168707
 swe_refrac_extended(14.168707435917, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 14.168707
-rv[1] = 14.163620
-rv[2] = -0.005087
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(14)
+  [0]=>
+  float(14.168707)
+  [1]=>
+  float(14.16362)
+  [2]=>
+  float(-0.005087)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(14)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 317.58169019832, 3.5727768041555)
 planet Mercury	lon=317.581690	lat=3.572777
 horizon coordinates
-xaz[0] = 33.015528
-xaz[1] = 23.054619
-xaz[2] = 23.088824
+array(3) {
+  [0]=>
+  float(33.015528)
+  [1]=>
+  float(23.054619)
+  [2]=>
+  float(23.088824)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 33.015528055456, 23.054619397828)
 converted back	lon=317.581690	lat=3.572777
 swe_refrac(23.054619397828, 0, 30, SE_TRUE_TO_APP)
 app. alt = 23.054619
 swe_refrac_extended(23.054619397828, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 23.054619
-rv[1] = 23.051554
-rv[2] = -0.003066
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(23)
+  [0]=>
+  float(23.054619)
+  [1]=>
+  float(23.051554)
+  [2]=>
+  float(-0.003066)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(23)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 286.27461775725, 0.45824983922003)
 planet Venus	lon=286.274618	lat=0.458250
 horizon coordinates
-xaz[0] = 55.087223
-xaz[1] = 0.074100
-xaz[2] = 0.490626
+array(3) {
+  [0]=>
+  float(55.087223)
+  [1]=>
+  float(0.0741)
+  [2]=>
+  float(0.490626)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 55.087222851488, 0.074099595114085)
 converted back	lon=286.274618	lat=0.458250
 swe_refrac(0.074099595114085, 0, 30, SE_TRUE_TO_APP)
 app. alt = 0.074100
 swe_refrac_extended(0.074099595114085, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 0.074100
-rv[1] = 0.030375
-rv[2] = -0.043725
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(0)
+  [0]=>
+  float(0.0741)
+  [1]=>
+  float(0.030375)
+  [2]=>
+  float(-0.043725)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(0)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 84.347673788076, 3.269827510972)
 planet Mars	lon=84.347674	lat=3.269828
 horizon coordinates
-xaz[0] = 249.152267
-xaz[1] = 17.317286
-xaz[2] = 17.363768
+array(3) {
+  [0]=>
+  float(249.152267)
+  [1]=>
+  float(17.317286)
+  [2]=>
+  float(17.363768)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 249.15226738768, 17.317286330931)
 converted back	lon=84.347674	lat=3.269828
 swe_refrac(17.317286330931, 0, 30, SE_TRUE_TO_APP)
 app. alt = 17.317286
 swe_refrac_extended(17.317286330931, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 17.317286
-rv[1] = 17.313116
-rv[2] = -0.004171
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(17)
+  [0]=>
+  float(17.317286)
+  [1]=>
+  float(17.313116)
+  [2]=>
+  float(-0.004171)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(17)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 281.08104864944, 0.11611585917234)
 planet Jupiter	lon=281.081049	lat=0.116116
 horizon coordinates
-xaz[0] = 58.699497
-xaz[1] = -3.675366
-xaz[2] = -3.675366
+array(3) {
+  [0]=>
+  float(58.699497)
+  [1]=>
+  float(-3.675366)
+  [2]=>
+  float(-3.675366)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 58.699496773198, -3.6753655043035)
 converted back	lon=281.081049	lat=0.116116
 swe_refrac(-3.6753655043035, 0, 30, SE_TRUE_TO_APP)
 app. alt = -3.675366
 swe_refrac_extended(-3.6753655043035, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = -3.675366
-rv[1] = -3.675366
-rv[2] = 0.000000
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(-3)
+  [0]=>
+  float(-3.675366)
+  [1]=>
+  float(-3.675366)
+  [2]=>
+  float(0)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(-3)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 156.55664098162, 1.807919057902)
 planet Saturn	lon=156.556641	lat=1.807919
 horizon coordinates
-xaz[0] = 192.185196
-xaz[1] = -29.463314
-xaz[2] = -29.463314
+array(3) {
+  [0]=>
+  float(192.185196)
+  [1]=>
+  float(-29.463314)
+  [2]=>
+  float(-29.463314)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 192.18519630456, -29.463314277349)
 converted back	lon=156.556641	lat=1.807919
 swe_refrac(-29.463314277349, 0, 30, SE_TRUE_TO_APP)
 app. alt = -29.463314
 swe_refrac_extended(-29.463314277349, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = -29.463314
-rv[1] = -29.463314
-rv[2] = 0.000000
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(-29)
+  [0]=>
+  float(-29.463314)
+  [1]=>
+  float(-29.463314)
+  [2]=>
+  float(0)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(-29)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 346.91144266408, -0.73880594411775)
 planet Uranus	lon=346.911443	lat=-0.738806
 horizon coordinates
-xaz[0] = 1.848702
-xaz[1] = 35.134978
-xaz[2] = 35.155710
+array(3) {
+  [0]=>
+  float(1.848702)
+  [1]=>
+  float(35.134978)
+  [2]=>
+  float(35.15571)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 1.8487020305536, 35.134977545971)
 converted back	lon=346.911443	lat=-0.738806
 swe_refrac(35.134977545971, 0, 30, SE_TRUE_TO_APP)
 app. alt = 35.134978
 swe_refrac_extended(35.134977545971, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 35.134978
-rv[1] = 35.133121
-rv[2] = -0.001856
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(35)
+  [0]=>
+  float(35.134978)
+  [1]=>
+  float(35.133121)
+  [2]=>
+  float(-0.001856)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(35)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 321.54464479387, -0.29238086027684)
 planet Neptune	lon=321.544645	lat=-0.292381
 horizon coordinates
-xaz[0] = 27.052450
-xaz[1] = 22.432809
-xaz[2] = 22.468064
+array(3) {
+  [0]=>
+  float(27.05245)
+  [1]=>
+  float(22.432809)
+  [2]=>
+  float(22.468064)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 27.052449976595, 22.432808718829)
 converted back	lon=321.544645	lat=-0.292381
 swe_refrac(22.432808718829, 0, 30, SE_TRUE_TO_APP)
 app. alt = 22.432809
 swe_refrac_extended(22.432808718829, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = 22.432809
-rv[1] = 22.429649
-rv[2] = -0.003160
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(22)
+  [0]=>
+  float(22.432809)
+  [1]=>
+  float(22.429649)
+  [2]=>
+  float(-0.00316)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(22)
+}
 swe_azalt(2454503.06, SE_ECL2HOR, 12.1, 49, 330, 0, 30, 270.33845556252, 6.2835633668811)
 planet Pluto	lon=270.338456	lat=6.283563
 horizon coordinates
-xaz[0] = 70.859347
-xaz[1] = -6.169858
-xaz[2] = -6.169858
+array(3) {
+  [0]=>
+  float(70.859347)
+  [1]=>
+  float(-6.169858)
+  [2]=>
+  float(-6.169858)
+}
 swe_azalt_rev(2454503.06, SE_HOR2ECL, 12.1, 49, 330, 70.8593465128, -6.1698581235873)
 converted back	lon=270.338456	lat=6.283563
 swe_refrac(-6.1698581235873, 0, 30, SE_TRUE_TO_APP)
 app. alt = -6.169858
 swe_refrac_extended(-6.1698581235873, 330, 0, 30, 10.0, SE_TRUE_TO_APP)
-rv[0] = -6.169858
-rv[1] = -6.169858
-rv[2] = 0.000000
-rv[3] = -0.582825
+array(6) {
+  ["rc"]=>
+  int(-6)
+  [0]=>
+  float(-6.169858)
+  [1]=>
+  float(-6.169858)
+  [2]=>
+  float(0)
+  [3]=>
+  float(-0.582825)
+  ["retflag"]=>
+  float(-6)
+}

--- a/tests/swe_cotrans.phpt
+++ b/tests/swe_cotrans.phpt
@@ -8,14 +8,9 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
-$converted = swe_cotrans(121.34, 43.57, 1.0, 23.4);
-
-$converted = array_map(function ($value) {
-    return round($value, 6);
-}, $converted);
-
-var_dump($converted);
+var_dump(Format::round(swe_cotrans(121.34, 43.57, 1.0, 23.4)));
 ?>
 --EXPECT--
 array(3) {

--- a/tests/swe_cotrans_sp.phpt
+++ b/tests/swe_cotrans_sp.phpt
@@ -8,14 +8,9 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
-$converted = swe_cotrans_sp(121.34, 43.57, 1.0, 1.1, 5.5, 1.0, 23.4);
-
-$converted = array_map(function ($value) {
-    return round($value, 6);
-}, $converted);
-
-var_dump($converted);
+var_dump(Format::round(swe_cotrans_sp(121.34, 43.57, 1.0, 1.1, 5.5, 1.0, 23.4)));
 ?>
 --EXPECT--
 array(6) {

--- a/tests/swe_lun_eclipse.phpt
+++ b/tests/swe_lun_eclipse.phpt
@@ -10,87 +10,142 @@ if (!extension_loaded('swephp')) {
 <?php
 include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
+
 echo "swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0)\n";
 $rv = swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
 $d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
-print_array( $rv['tret'], 8, 'tret');
+var_dump(Format::round($rv['tret']));
 $geo = array(12.1, 49.0, 330);
+
 echo "swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0)\n";
 $rv = swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
 $d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
-print_array( $geo, 3, 'geo');
-print_array( $rv['tret'], 10, 'tret');
-print_array( $rv['attr'], 11, 'attr');
+var_dump(Format::round($geo));
+var_dump(Format::round($rv['tret']));
+var_dump(Format::round($rv['attr']));
+
 echo "swe_lun_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2])\n";
 $rv = swe_lun_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2]);
 printf("%f %s\n",  $tjd_ut,  $d);
-print_array( $geo, 3, 'geo');
-print_array( $rv['attr'], 11, 'attr');
-
-function print_array($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++)
-   printf( "%s[%d] = %f\n", $name, $i, $arr[$i]);;
-}
+var_dump(Format::round($geo));
+var_dump(Format::round($rv['attr']));
 ?>
 --EXPECT--
 swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0)
 retflag = 4 100
 2454517.643069 2008 2 21  3:26:1 UT
-tret[0] = 2454517.643069
-tret[1] = 0.000000
-tret[2] = 2454517.571723
-tret[3] = 2454517.714419
-tret[4] = 2454517.625804
-tret[5] = 2454517.660351
-tret[6] = 2454517.525389
-tret[7] = 2454517.760855
+array(8) {
+  [0]=>
+  float(2454517.643069)
+  [1]=>
+  float(0)
+  [2]=>
+  float(2454517.571723)
+  [3]=>
+  float(2454517.714419)
+  [4]=>
+  float(2454517.625804)
+  [5]=>
+  float(2454517.660351)
+  [6]=>
+  float(2454517.525389)
+  [7]=>
+  float(2454517.760855)
+}
 swe_lun_eclipse_when_loc(2454517.643069, SEFLG_SWIEPH, 12.1, 49, 330, 0)
 retflag = 29584 111001110010000
 2454695.382052 2008 8 16  21:10:9 UT
-geo[0] = 12.100000
-geo[1] = 49.000000
-geo[2] = 330.000000
-tret[0] = 2454695.382052
-tret[1] = 0.000000
-tret[2] = 2454695.316710
-tret[3] = 2454695.447390
-tret[4] = 0.000000
-tret[5] = 0.000000
-tret[6] = 2454695.267206
-tret[7] = 2454695.496798
-tret[8] = 0.000000
-tret[9] = 0.000000
-attr[0] = 0.807613
-attr[1] = 1.836650
-attr[2] = 0.000000
-attr[3] = 0.000000
-attr[4] = 326.988587
-attr[5] = 21.362590
-attr[6] = 21.402251
-attr[7] = 0.530161
-attr[8] = 0.807613
-attr[9] = 138.000000
-attr[10] = 28.000000
+array(3) {
+  [0]=>
+  float(12.1)
+  [1]=>
+  float(49)
+  [2]=>
+  int(330)
+}
+array(10) {
+  [0]=>
+  float(2454695.382052)
+  [1]=>
+  float(0)
+  [2]=>
+  float(2454695.31671)
+  [3]=>
+  float(2454695.44739)
+  [4]=>
+  float(0)
+  [5]=>
+  float(0)
+  [6]=>
+  float(2454695.267206)
+  [7]=>
+  float(2454695.496798)
+  [8]=>
+  float(0)
+  [9]=>
+  float(0)
+}
+array(11) {
+  [0]=>
+  float(0.807613)
+  [1]=>
+  float(1.83665)
+  [2]=>
+  float(0)
+  [3]=>
+  float(0)
+  [4]=>
+  float(326.988587)
+  [5]=>
+  float(21.36259)
+  [6]=>
+  float(21.402251)
+  [7]=>
+  float(0.530161)
+  [8]=>
+  float(0.807613)
+  [9]=>
+  float(138)
+  [10]=>
+  float(28)
+}
 swe_lun_eclipse_how(2454695.3820517, SEFLG_SWIEPH, 12.1, 49, 330)
 2454695.382052 2008 8 16  21:10:9 UT
-geo[0] = 12.100000
-geo[1] = 49.000000
-geo[2] = 330.000000
-attr[0] = 0.807613
-attr[1] = 1.836650
-attr[2] = 0.000000
-attr[3] = 0.000000
-attr[4] = 326.988587
-attr[5] = 21.362590
-attr[6] = 21.402251
-attr[7] = 0.530161
-attr[8] = 0.807613
-attr[9] = 138.000000
-attr[10] = 28.000000
+array(3) {
+  [0]=>
+  float(12.1)
+  [1]=>
+  float(49)
+  [2]=>
+  int(330)
+}
+array(11) {
+  [0]=>
+  float(0.807613)
+  [1]=>
+  float(1.83665)
+  [2]=>
+  float(0)
+  [3]=>
+  float(0)
+  [4]=>
+  float(326.988587)
+  [5]=>
+  float(21.36259)
+  [6]=>
+  float(21.402251)
+  [7]=>
+  float(0.530161)
+  [8]=>
+  float(0.807613)
+  [9]=>
+  float(138)
+  [10]=>
+  float(28)
+}

--- a/tests/swe_lun_eclipse.phpt
+++ b/tests/swe_lun_eclipse.phpt
@@ -8,12 +8,13 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
 echo "swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0)\n";
 $rv = swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = print_date($tjd_ut);
+$d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 print_array( $rv['tret'], 8, 'tret');
 $geo = array(12.1, 49.0, 330);
@@ -21,7 +22,7 @@ echo "swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2],
 $rv = swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = print_date($tjd_ut);
+$d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 print_array( $geo, 3, 'geo');
 print_array( $rv['tret'], 10, 'tret');
@@ -31,15 +32,6 @@ $rv = swe_lun_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2]);
 printf("%f %s\n",  $tjd_ut,  $d);
 print_array( $geo, 3, 'geo');
 print_array( $rv['attr'], 11, 'attr');
-
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
 
 function print_array($arr, $n, $name)
 {

--- a/tests/swe_lun_eclipse.phpt
+++ b/tests/swe_lun_eclipse.phpt
@@ -15,7 +15,7 @@ echo "swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0)\n";
 $rv = swe_lun_eclipse_when(2454466.5, SEFLG_SWIEPH, 0, 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = Format::date($tjd_ut);
+$d = Format::asUtc($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 var_dump(Format::round($rv['tret']));
 $geo = array(12.1, 49.0, 330);
@@ -24,7 +24,7 @@ echo "swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2],
 $rv = swe_lun_eclipse_when_loc($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = Format::date($tjd_ut);
+$d = Format::asUtc($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 var_dump(Format::round($geo));
 var_dump(Format::round($rv['tret']));

--- a/tests/swe_lun_occult.phpt
+++ b/tests/swe_lun_occult.phpt
@@ -8,26 +8,18 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
 echo "swe_lun_occult_when_glob for Venus\n";
 $rv = swe_lun_occult_when_glob(2454466.5, SE_VENUS, "", SEFLG_SWIEPH, 0, 0);
 var_dump($rv);
 $tjd_ut = $rv['tret'][0];
-var_dump($tjd_ut, print_date($tjd_ut));
+var_dump($tjd_ut, Format::date($tjd_ut));
 echo "swe_lun_occult_where for Venus\n";
 var_dump(swe_lun_occult_where($tjd_ut, SE_VENUS, "", SEFLG_SWIEPH));
 echo "swe_lun_occult_when_loc for Venus\n";
 $rv = swe_lun_occult_when_loc(2454466.5, SE_VENUS, "", SEFLG_SWIEPH, 12.1, 49.0, 330, 0);
 var_dump($rv);
-
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
 ?>
 --EXPECT--
 swe_lun_occult_when_glob for Venus

--- a/tests/swe_lun_occult.phpt
+++ b/tests/swe_lun_occult.phpt
@@ -14,7 +14,7 @@ echo "swe_lun_occult_when_glob for Venus\n";
 $rv = swe_lun_occult_when_glob(2454466.5, SE_VENUS, "", SEFLG_SWIEPH, 0, 0);
 var_dump($rv);
 $tjd_ut = $rv['tret'][0];
-var_dump($tjd_ut, Format::date($tjd_ut));
+var_dump($tjd_ut, Format::asUtc($tjd_ut));
 echo "swe_lun_occult_where for Venus\n";
 var_dump(swe_lun_occult_where($tjd_ut, SE_VENUS, "", SEFLG_SWIEPH));
 echo "swe_lun_occult_when_loc for Venus\n";

--- a/tests/swe_pheno.phpt
+++ b/tests/swe_pheno.phpt
@@ -8,201 +8,345 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
+
 for ($p = SE_SUN; $p <= SE_PLUTO; $p++) {
   $pnam = swe_get_planet_name($p);
   echo "swe_pheno(2454503.6, $p, SEFLG_SWIEPH)\n";
   $rv = swe_pheno(2454503.6, $p, SEFLG_SWIEPH);\
   printf( "%s\tretflag = %d %b\n", $pnam, $rv['retflag'], $rv['retflag']);
-  print_array( $rv['attr'], 6, 'attr');
+  var_dump(Format::round($rv['attr']));
 }
+
 for ($p = SE_SUN; $p <= SE_PLUTO; $p++) {
   $pnam = swe_get_planet_name($p);
   echo "swe_pheno_ut(2453503.6, $p, SEFLG_SWIEPH)\n";
   $rv = swe_pheno_ut(2453503.6, $p, SEFLG_SWIEPH);\
   printf( "%s\tretflag = %d %b\n", $pnam, $rv['retflag'], $rv['retflag']);
-  print_array( $rv['attr'], 6, 'attr');
+  var_dump(Format::round($rv['attr']));
 }
 
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
-
-function print_array($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++)
-   printf( "%s[%d] = %f\n", $name, $i, $arr[$i]);;
-}
-function print_array_t($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++) {
-   printf( "%s[%d] = %f %s\n", $name, $i, $arr[$i], print_date($arr[$i]));;
-  }
-}
 ?>
 --EXPECT--
 swe_pheno(2454503.6, 0, SEFLG_SWIEPH)
 Sun	retflag = 2 10
-attr[0] = 0.000000
-attr[1] = 0.000000
-attr[2] = 0.000000
-attr[3] = 0.540611
-attr[4] = -26.890235
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(0)
+  [1]=>
+  float(0)
+  [2]=>
+  float(0)
+  [3]=>
+  float(0.540611)
+  [4]=>
+  float(-26.890235)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 1, SEFLG_SWIEPH)
 Moon	retflag = 2 10
-attr[0] = 178.794517
-attr[1] = 0.000111
-attr[2] = 1.202223
-attr[3] = 0.519086
-attr[4] = -3.987935
-attr[5] = 0.952789
+array(6) {
+  [0]=>
+  float(178.794517)
+  [1]=>
+  float(0.000111)
+  [2]=>
+  float(1.202223)
+  [3]=>
+  float(0.519086)
+  [4]=>
+  float(-3.987935)
+  [5]=>
+  float(0.952789)
+}
 swe_pheno(2454503.6, 2, SEFLG_SWIEPH)
 Mercury	retflag = 2 10
-attr[0] = 169.154363
-attr[1] = 0.008931
-attr[2] = 3.694023
-attr[3] = 0.002864
-attr[4] = 5.258810
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(169.154363)
+  [1]=>
+  float(0.008931)
+  [2]=>
+  float(3.694023)
+  [3]=>
+  float(0.002864)
+  [4]=>
+  float(5.25881)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 3, SEFLG_SWIEPH)
 Venus	retflag = 2 10
-attr[0] = 44.050208
-attr[1] = 0.859365
-attr[2] = 30.741319
-attr[3] = 0.003387
-attr[4] = -3.937999
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(44.050208)
+  [1]=>
+  float(0.859365)
+  [2]=>
+  float(30.741319)
+  [3]=>
+  float(0.003387)
+  [4]=>
+  float(-3.937999)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 4, SEFLG_SWIEPH)
 Mars	retflag = 2 10
-attr[0] = 29.198518
-attr[1] = 0.936467
-attr[2] = 126.645369
-attr[3] = 0.003139
-attr[4] = -0.412362
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(29.198518)
+  [1]=>
+  float(0.936467)
+  [2]=>
+  float(126.645369)
+  [3]=>
+  float(0.003139)
+  [4]=>
+  float(-0.412362)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 5, SEFLG_SWIEPH)
 Jupiter	retflag = 2 10
-attr[0] = 6.430373
-attr[1] = 0.996854
-attr[2] = 36.485708
-attr[3] = 0.008934
-attr[4] = -1.888970
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(6.430373)
+  [1]=>
+  float(0.996854)
+  [2]=>
+  float(36.485708)
+  [3]=>
+  float(0.008934)
+  [4]=>
+  float(-1.88897)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 6, SEFLG_SWIEPH)
 Saturn	retflag = 2 10
-attr[0] = 1.981945
-attr[1] = 0.999701
-attr[2] = 161.077732
-attr[3] = 0.005350
-attr[4] = 0.321585
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(1.981945)
+  [1]=>
+  float(0.999701)
+  [2]=>
+  float(161.077732)
+  [3]=>
+  float(0.00535)
+  [4]=>
+  float(0.321585)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 7, SEFLG_SWIEPH)
 Uranus	retflag = 2 10
-attr[0] = 1.378549
-attr[1] = 0.999855
-attr[2] = 29.269562
-attr[3] = 0.000927
-attr[4] = 5.970784
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(1.378549)
+  [1]=>
+  float(0.999855)
+  [2]=>
+  float(29.269562)
+  [3]=>
+  float(0.000927)
+  [4]=>
+  float(5.970784)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 8, SEFLG_SWIEPH)
 Neptune	retflag = 2 10
-attr[0] = 0.132519
-attr[1] = 0.999999
-attr[2] = 3.897906
-attr[3] = 0.000608
-attr[4] = 7.847212
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(0.132519)
+  [1]=>
+  float(0.999999)
+  [2]=>
+  float(3.897906)
+  [3]=>
+  float(0.000608)
+  [4]=>
+  float(7.847212)
+  [5]=>
+  float(0)
+}
 swe_pheno(2454503.6, 9, SEFLG_SWIEPH)
 Pluto	retflag = 2 10
-attr[0] = 1.326519
-attr[1] = 0.999866
-attr[2] = 47.641525
-attr[3] = 0.000028
-attr[4] = 14.015978
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(1.326519)
+  [1]=>
+  float(0.999866)
+  [2]=>
+  float(47.641525)
+  [3]=>
+  float(2.8E-5)
+  [4]=>
+  float(14.015978)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 0, SEFLG_SWIEPH)
 Sun	retflag = 2 10
-attr[0] = 0.000000
-attr[1] = 0.000000
-attr[2] = 0.000000
-attr[3] = 0.527609
-attr[4] = -26.837369
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(0)
+  [1]=>
+  float(0)
+  [2]=>
+  float(0)
+  [3]=>
+  float(0.527609)
+  [4]=>
+  float(-26.837369)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 1, SEFLG_SWIEPH)
 Moon	retflag = 2 10
-attr[0] = 125.504320
-attr[1] = 0.209618
-attr[2] = 54.371336
-attr[3] = 0.493610
-attr[4] = -8.359463
-attr[5] = 0.906096
+array(6) {
+  [0]=>
+  float(125.50432)
+  [1]=>
+  float(0.209618)
+  [2]=>
+  float(54.371336)
+  [3]=>
+  float(0.49361)
+  [4]=>
+  float(-8.359463)
+  [5]=>
+  float(0.906096)
+}
 swe_pheno_ut(2453503.6, 2, SEFLG_SWIEPH)
 Mercury	retflag = 2 10
-attr[0] = 66.367254
-attr[1] = 0.700436
-attr[2] = 21.429813
-attr[3] = 0.001695
-attr[4] = -0.267628
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(66.367254)
+  [1]=>
+  float(0.700436)
+  [2]=>
+  float(21.429813)
+  [3]=>
+  float(0.001695)
+  [4]=>
+  float(-0.267628)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 3, SEFLG_SWIEPH)
 Venus	retflag = 2 10
-attr[0] = 15.751581
-attr[1] = 0.981224
-attr[2] = 11.159051
-attr[3] = 0.002752
-attr[4] = -3.899240
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(15.751581)
+  [1]=>
+  float(0.981224)
+  [2]=>
+  float(11.159051)
+  [3]=>
+  float(0.002752)
+  [4]=>
+  float(-3.89924)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 4, SEFLG_SWIEPH)
 Mars	retflag = 2 10
-attr[0] = 43.451204
-attr[1] = 0.862980
-attr[2] = 73.779834
-attr[3] = 0.001987
-attr[4] = 0.466287
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(43.451204)
+  [1]=>
+  float(0.86298)
+  [2]=>
+  float(73.779834)
+  [3]=>
+  float(0.001987)
+  [4]=>
+  float(0.466287)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 5, SEFLG_SWIEPH)
 Jupiter	retflag = 2 10
-attr[0] = 7.213335
-attr[1] = 0.996043
-attr[2] = 137.273177
-attr[3] = 0.011465
-attr[4] = -2.334115
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(7.213335)
+  [1]=>
+  float(0.996043)
+  [2]=>
+  float(137.273177)
+  [3]=>
+  float(0.011465)
+  [4]=>
+  float(-2.334115)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 6, SEFLG_SWIEPH)
 Saturn	retflag = 2 10
-attr[0] = 5.552012
-attr[1] = 0.997654
-attr[2] = 60.297034
-attr[3] = 0.004680
-attr[4] = 0.214603
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(5.552012)
+  [1]=>
+  float(0.997654)
+  [2]=>
+  float(60.297034)
+  [3]=>
+  float(0.00468)
+  [4]=>
+  float(0.214603)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 7, SEFLG_SWIEPH)
 Uranus	retflag = 2 10
-attr[0] = 2.746480
-attr[1] = 0.999426
-attr[2] = 72.107567
-attr[3] = 0.000955
-attr[4] = 5.914068
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(2.74648)
+  [1]=>
+  float(0.999426)
+  [2]=>
+  float(72.107567)
+  [3]=>
+  float(0.000955)
+  [4]=>
+  float(5.914068)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 8, SEFLG_SWIEPH)
 Neptune	retflag = 2 10
-attr[0] = 1.920724
-attr[1] = 0.999719
-attr[2] = 94.845990
-attr[3] = 0.000630
-attr[4] = 7.772944
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(1.920724)
+  [1]=>
+  float(0.999719)
+  [2]=>
+  float(94.84599)
+  [3]=>
+  float(0.00063)
+  [4]=>
+  float(7.772944)
+  [5]=>
+  float(0)
+}
 swe_pheno_ut(2453503.6, 9, SEFLG_SWIEPH)
 Pluto	retflag = 2 10
-attr[0] = 1.010404
-attr[1] = 0.999922
-attr[2] = 147.501316
-attr[3] = 0.000030
-attr[4] = 13.845449
-attr[5] = 0.000000
+array(6) {
+  [0]=>
+  float(1.010404)
+  [1]=>
+  float(0.999922)
+  [2]=>
+  float(147.501316)
+  [3]=>
+  float(3.0E-5)
+  [4]=>
+  float(13.845449)
+  [5]=>
+  float(0)
+}

--- a/tests/swe_rise_trans_etc.phpt
+++ b/tests/swe_rise_trans_etc.phpt
@@ -9,6 +9,7 @@ if (!extension_loaded('swephp')) {
 --FILE--
 <?php
 
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
 
 # calc planet position
@@ -67,7 +68,7 @@ for($i = 0; $i < 4; $i++) {
   $ptrans[$i] = array(
     'what' => $flagnam[$i],
     'tr'   => $tr,
-    'when' => print_date($tr)
+    'when' => Format::date($tr)
   );
 }
 echo "rise $pnam: \n";
@@ -84,20 +85,12 @@ for($i = 0; $i < 4; $i++) {
   $strans[$i] = array(
     'what' => $flagnam[$i],
     'tr'   => $tr,
-    'when' => print_date($tr)
+    'when' => Format::date($tr)
   );
 }
 echo "rise $starname: \n";
 var_dump($strans); 
 
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
 ?>
 --EXPECT--
 planets: 

--- a/tests/swe_rise_trans_etc.phpt
+++ b/tests/swe_rise_trans_etc.phpt
@@ -68,7 +68,7 @@ for($i = 0; $i < 4; $i++) {
   $ptrans[$i] = array(
     'what' => $flagnam[$i],
     'tr'   => $tr,
-    'when' => Format::date($tr)
+    'when' => Format::asUtc($tr)
   );
 }
 echo "rise $pnam: \n";
@@ -85,7 +85,7 @@ for($i = 0; $i < 4; $i++) {
   $strans[$i] = array(
     'what' => $flagnam[$i],
     'tr'   => $tr,
-    'when' => Format::date($tr)
+    'when' => Format::asUtc($tr)
   );
 }
 echo "rise $starname: \n";

--- a/tests/swe_sol_eclipse.phpt
+++ b/tests/swe_sol_eclipse.phpt
@@ -16,7 +16,7 @@ echo "swe_sol_eclipse_when_glob(2454466.5, SEFLG_SWIEPH, 0, 0)\n";
 $rv = swe_sol_eclipse_when_glob(2454466.5, SEFLG_SWIEPH, 0, 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = Format::date($tjd_ut);
+$d = Format::asUtc($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 var_dump(Format::jdtWithUtc(array_slice($rv['tret'], 0, 8)));
 

--- a/tests/swe_sol_eclipse.phpt
+++ b/tests/swe_sol_eclipse.phpt
@@ -23,27 +23,22 @@ print_array_t( $rv['tret'], 8, 'tret');
 echo "swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH)\n";
 $rv = swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
-print_array( $rv['geopos'], 2, 'geopos');
-print_array( $rv['attr'], 11, 'attr');
+var_dump(Format::round($rv['geopos']));
+var_dump(Format::round(array_slice($rv['attr'], 0, 11)));
 $geo = array(-153.1, -65.0, 0);
 
 echo "swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0)\n";
 $rv = swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
-print_array( $rv['tret'], 7, 'tret');
+var_dump(Format::round($rv['tret']));
 print_array_t( $rv['tret'], 5, 'tret');
-print_array( $rv['attr'], 11, 'attr');
+var_dump(Format::round(array_slice($rv['attr'], 0, 11)));
 
 echo "swe_sol_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2])\n";
 $rv = swe_sol_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2]);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
-print_array( $rv['attr'], 11, 'attr');
+var_dump(Format::round(array_slice($rv['attr'], 0, 11)));
 
-function print_array($arr, $n, $name)
-{
-  for ($i = 0; $i < $n; $i++)
-   printf( "%s[%d] = %f\n", $name, $i, $arr[$i]);;
-}
 function print_array_t($arr, $n, $name)
 {
   for ($i = 0; $i < $n; $i++) {
@@ -65,54 +60,106 @@ tret[6] = 2454503.641705 2008 2 7  3:24:3 UT
 tret[7] = 2454503.684978 2008 2 7  4:26:22 UT
 swe_sol_eclipse_where(2454503.6632119, SEFLG_SWIEPH)
 retflag = 9 1001
-geopos[0] = -150.265756
-geopos[1] = -67.547263
-attr[0] = 0.980885
-attr[1] = 0.965768
-attr[2] = 0.932707
-attr[3] = 123.542311
-attr[4] = 88.565979
-attr[5] = 16.228758
-attr[6] = 16.283962
-attr[7] = 0.001081
-attr[8] = 0.965768
-attr[9] = 121.000000
-attr[10] = 60.000000
+array(2) {
+  [0]=>
+  float(-150.265756)
+  [1]=>
+  float(-67.547263)
+}
+array(11) {
+  [0]=>
+  float(0.980885)
+  [1]=>
+  float(0.965768)
+  [2]=>
+  float(0.932707)
+  [3]=>
+  float(123.542311)
+  [4]=>
+  float(88.565979)
+  [5]=>
+  float(16.228758)
+  [6]=>
+  float(16.283962)
+  [7]=>
+  float(0.001081)
+  [8]=>
+  float(0.965768)
+  [9]=>
+  float(121)
+  [10]=>
+  float(60)
+}
 swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, -153.1, -65, 0, 0)
 retflag = 8072 1111110001000
-tret[0] = 2454503.666762
-tret[1] = 2454503.622761
-tret[2] = 2454503.666048
-tret[3] = 2454503.667476
-tret[4] = 2454503.708686
-tret[5] = -67.547263
-tret[6] = 0.000000
+array(7) {
+  [0]=>
+  float(2454503.666762)
+  [1]=>
+  float(2454503.622761)
+  [2]=>
+  float(2454503.666048)
+  [3]=>
+  float(2454503.667476)
+  [4]=>
+  float(2454503.708686)
+  [5]=>
+  float(0)
+  [6]=>
+  float(0)
+}
 tret[0] = 2454503.666762 2008 2 7  4:0:8 UT
 tret[1] = 2454503.622761 2008 2 7  2:56:46 UT
 tret[2] = 2454503.666048 2008 2 7  3:59:6 UT
 tret[3] = 2454503.667476 2008 2 7  4:1:10 UT
 tret[4] = 2454503.708686 2008 2 7  5:0:30 UT
-attr[0] = 0.976954
-attr[1] = 0.965959
-attr[2] = 0.933078
-attr[3] = 123.624143
-attr[4] = 89.232618
-attr[5] = 16.805076
-attr[6] = 16.858404
-attr[7] = 0.003258
-attr[8] = 0.965959
-attr[9] = 121.000000
-attr[10] = 60.000000
+array(11) {
+  [0]=>
+  float(0.976954)
+  [1]=>
+  float(0.965959)
+  [2]=>
+  float(0.933078)
+  [3]=>
+  float(123.624143)
+  [4]=>
+  float(89.232618)
+  [5]=>
+  float(16.805076)
+  [6]=>
+  float(16.858404)
+  [7]=>
+  float(0.003258)
+  [8]=>
+  float(0.965959)
+  [9]=>
+  float(121)
+  [10]=>
+  float(60)
+}
 swe_sol_eclipse_how(2454503.6632119, SEFLG_SWIEPH, -153.1, -65, 0)
 retflag = 145 10010001
-attr[0] = 0.901653
-attr[1] = 0.966069
-attr[2] = 0.862672
-attr[3] = 123.542311
-attr[4] = 90.389784
-attr[5] = 17.346140
-attr[6] = 17.397817
-attr[7] = 0.043996
-attr[8] = 0.901653
-attr[9] = 121.000000
-attr[10] = 60.000000
+array(11) {
+  [0]=>
+  float(0.901653)
+  [1]=>
+  float(0.966069)
+  [2]=>
+  float(0.862672)
+  [3]=>
+  float(123.542311)
+  [4]=>
+  float(90.389784)
+  [5]=>
+  float(17.34614)
+  [6]=>
+  float(17.397817)
+  [7]=>
+  float(0.043996)
+  [8]=>
+  float(0.901653)
+  [9]=>
+  float(121)
+  [10]=>
+  float(60)
+}

--- a/tests/swe_sol_eclipse.phpt
+++ b/tests/swe_sol_eclipse.phpt
@@ -18,7 +18,7 @@ printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
 $d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
-print_array_t( $rv['tret'], 8, 'tret');
+var_dump(Format::jdtWithUtc(array_slice($rv['tret'], 0, 8)));
 
 echo "swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH)\n";
 $rv = swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH);
@@ -31,7 +31,7 @@ echo "swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2
 $rv = swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 var_dump(Format::round($rv['tret']));
-print_array_t( $rv['tret'], 5, 'tret');
+var_dump(Format::jdtWithUtc(array_slice($rv['tret'], 0, 5)));
 var_dump(Format::round(array_slice($rv['attr'], 0, 11)));
 
 echo "swe_sol_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2])\n";
@@ -50,14 +50,24 @@ function print_array_t($arr, $n, $name)
 swe_sol_eclipse_when_glob(2454466.5, SEFLG_SWIEPH, 0, 0)
 retflag = 9 1001
 2454503.663212 2008 2 7  3:55:1 UT
-tret[0] = 2454503.663212 2008 2 7  3:55:1 UT
-tret[1] = 2454503.631145 2008 2 7  3:8:51 UT
-tret[2] = 2454503.568627 2008 2 7  1:38:49 UT
-tret[3] = 2454503.758221 2008 2 7  6:11:50 UT
-tret[4] = 2454503.638833 2008 2 7  3:19:55 UT
-tret[5] = 2454503.687824 2008 2 7  4:30:28 UT
-tret[6] = 2454503.641705 2008 2 7  3:24:3 UT
-tret[7] = 2454503.684978 2008 2 7  4:26:22 UT
+array(8) {
+  [0]=>
+  string(34) "2454503.663212 2008 2 7  3:55:1 UT"
+  [1]=>
+  string(34) "2454503.631145 2008 2 7  3:8:51 UT"
+  [2]=>
+  string(35) "2454503.568627 2008 2 7  1:38:49 UT"
+  [3]=>
+  string(35) "2454503.758221 2008 2 7  6:11:50 UT"
+  [4]=>
+  string(35) "2454503.638833 2008 2 7  3:19:55 UT"
+  [5]=>
+  string(35) "2454503.687824 2008 2 7  4:30:28 UT"
+  [6]=>
+  string(34) "2454503.641705 2008 2 7  3:24:3 UT"
+  [7]=>
+  string(35) "2454503.684978 2008 2 7  4:26:22 UT"
+}
 swe_sol_eclipse_where(2454503.6632119, SEFLG_SWIEPH)
 retflag = 9 1001
 array(2) {
@@ -108,11 +118,18 @@ array(7) {
   [6]=>
   float(0)
 }
-tret[0] = 2454503.666762 2008 2 7  4:0:8 UT
-tret[1] = 2454503.622761 2008 2 7  2:56:46 UT
-tret[2] = 2454503.666048 2008 2 7  3:59:6 UT
-tret[3] = 2454503.667476 2008 2 7  4:1:10 UT
-tret[4] = 2454503.708686 2008 2 7  5:0:30 UT
+array(5) {
+  [0]=>
+  string(33) "2454503.666762 2008 2 7  4:0:8 UT"
+  [1]=>
+  string(35) "2454503.622761 2008 2 7  2:56:46 UT"
+  [2]=>
+  string(34) "2454503.666048 2008 2 7  3:59:6 UT"
+  [3]=>
+  string(34) "2454503.667476 2008 2 7  4:1:10 UT"
+  [4]=>
+  string(34) "2454503.708686 2008 2 7  5:0:30 UT"
+}
 array(11) {
   [0]=>
   float(0.976954)

--- a/tests/swe_sol_eclipse.phpt
+++ b/tests/swe_sol_eclipse.phpt
@@ -8,39 +8,36 @@ if (!extension_loaded('swephp')) {
 ?>
 --FILE--
 <?php
+
+include 'utility/Format.php';
 swe_set_ephe_path('./sweph/ephe');
+
 echo "swe_sol_eclipse_when_glob(2454466.5, SEFLG_SWIEPH, 0, 0)\n";
 $rv = swe_sol_eclipse_when_glob(2454466.5, SEFLG_SWIEPH, 0, 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 $tjd_ut = $rv['tret'][0];
-$d = print_date($tjd_ut);
+$d = Format::date($tjd_ut);
 printf("%f %s\n",  $tjd_ut,  $d);
 print_array_t( $rv['tret'], 8, 'tret');
+
 echo "swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH)\n";
 $rv = swe_sol_eclipse_where($tjd_ut, SEFLG_SWIEPH);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 print_array( $rv['geopos'], 2, 'geopos');
 print_array( $rv['attr'], 11, 'attr');
 $geo = array(-153.1, -65.0, 0);
+
 echo "swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0)\n";
 $rv = swe_sol_eclipse_when_loc(2454466.5, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2], 0);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 print_array( $rv['tret'], 7, 'tret');
 print_array_t( $rv['tret'], 5, 'tret');
 print_array( $rv['attr'], 11, 'attr');
+
 echo "swe_sol_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2])\n";
 $rv = swe_sol_eclipse_how($tjd_ut, SEFLG_SWIEPH, $geo[0], $geo[1], $geo[2]);
 printf( "retflag = %d %b\n", $rv['retflag'], $rv['retflag']);
 print_array( $rv['attr'], 11, 'attr');
-
-function print_date($t)
-{
-  $r = swe_jdut1_to_utc($t, SE_GREG_CAL);
-  $sec = floor($r['sec']);
-  $date = $r['year'] . " " .  $r['month'] . " " .  $r['day']  . "  " . $r['hour'] .":".$r['min'] .":".$sec .' UT';
-  # $date = $r['year'] . " / ss";
-  return $date;
-}
 
 function print_array($arr, $n, $name)
 {
@@ -50,7 +47,7 @@ function print_array($arr, $n, $name)
 function print_array_t($arr, $n, $name)
 {
   for ($i = 0; $i < $n; $i++) {
-   printf( "%s[%d] = %f %s\n", $name, $i, $arr[$i], print_date($arr[$i]));;
+   printf( "%s[%d] = %f %s\n", $name, $i, $arr[$i], Format::date($arr[$i]));;
   }
 }
 ?>

--- a/utility/Format.php
+++ b/utility/Format.php
@@ -8,6 +8,13 @@
 class Format
 {
     /**
+     * Default precision value to use for rounding.
+     *
+     * @const int
+     */
+    public const PRECISION = 6;
+
+    /**
      * Convert a Julian datetime value into a human-readable datetime string.
      *
      * @param float $jdt Julian datetime value.
@@ -36,7 +43,7 @@ class Format
      * @param int $precision Number of decimal places to keep.
      * @return array
      */
-    public static function round(array $input, int $precision = 6): array
+    public static function round(array $input, int $precision = Format::PRECISION): array
     {
         return array_map(function ($value) use ($precision) {
             return is_double($value) ? round($value, $precision) : $value;

--- a/utility/Format.php
+++ b/utility/Format.php
@@ -8,11 +8,32 @@
 class Format
 {
     /**
+     * Convert a Julian datetime value into a human-readable datetime string.
+     *
+     * @param float $jdt Julian datetime value.
+     * @return string
+     */
+    public static function date(float $jdt): string
+    {
+        $r = swe_jdut1_to_utc($jdt, SE_GREG_CAL);
+        $sec = floor($r['sec']);
+
+        return sprintf(
+            '%s %s %s  %s:%s:%s UT',
+            $r['year'],
+            $r['month'],
+            $r['day'],
+            $r['hour'],
+            $r['min'],
+            $sec
+        );
+    }
+
+    /**
      * Round all decimal values in an array to specified precision.
      *
      * @param array $input Input array.
      * @param int $precision Number of decimal places to keep.
-     *
      * @return array
      */
     public static function round(array $input, int $precision = 6): array

--- a/utility/Format.php
+++ b/utility/Format.php
@@ -20,7 +20,7 @@ class Format
      * @param float $jdt Julian datetime value.
      * @return string
      */
-    public static function date(float $jdt): string
+    public static function asUtc(float $jdt): string
     {
         $r = swe_jdut1_to_utc($jdt, SE_GREG_CAL);
         $sec = floor($r['sec']);
@@ -48,7 +48,7 @@ class Format
     {
         return array_map(function ($value) {
             return is_double($value)
-                ? sprintf('%f %s', round($value, Format::PRECISION), Format::date($value))
+                ? sprintf('%f %s', round($value, Format::PRECISION), Format::asUtc($value))
                 : $value;
         }, $input);
     }

--- a/utility/Format.php
+++ b/utility/Format.php
@@ -37,6 +37,23 @@ class Format
     }
 
     /**
+     * Convert an array of Julian datetime values into their human-readable
+     * datetime string equivalents, returning a rounded version of the
+     * original JDT value as well.
+     *
+     * @param array $input Input array.
+     * @return array
+     */
+    public static function jdtWithUtc(array $input): array
+    {
+        return array_map(function ($value) {
+            return is_double($value)
+                ? sprintf('%f %s', round($value, Format::PRECISION), Format::date($value))
+                : $value;
+        }, $input);
+    }
+
+    /**
      * Round all decimal values in an array to specified precision.
      *
      * @param array $input Input array.


### PR DESCRIPTION
Refs: https://github.com/cyjoelchen/php-sweph/issues/49

@aloistr

You do not need to review this unless you want to do so. I added you to this PR in case you are interested in seeing what was done. I decided to re-use the existing helper functionality as much as possible, which meant converting some of the verbose string formatting into simple `var_dump()` calls.

This meant I needed to change the test expectations, but I took great care to ensure that only the formatting (and not the values) were modified. You can select any given commit from the ones in this branch if you want to inspect more closely.
