### PR TITLE
Resolve false positive test results.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,5 +34,6 @@ jobs:
 
       - name: Run Tests.
         env:
+          NO_INTERACTION: 1
           REPORT_EXIT_STATUS: 1
-        run: yes n | make test
+        run: make test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,4 +33,6 @@ jobs:
           sudo make install
 
       - name: Run Tests.
+        env:
+          REPORT_EXIT_STATUS: 1
         run: yes n | make test

--- a/utility/Format.php
+++ b/utility/Format.php
@@ -12,7 +12,7 @@ class Format
      *
      * @const int
      */
-    public const PRECISION = 6;
+    const PRECISION = 6;
 
     /**
      * Convert a Julian datetime value into a human-readable datetime string.


### PR DESCRIPTION
Refs: #74 

Although the issue causing the test failures was effectively moot (there was an invalid use of the `public` visibility setting in the test `Format` class, so no production code was impacted), this PR resolves something more important:

We were receiving a false positive from the Github workflow tests as `make test` was previously always returning `0` even if any of the individual tests failed. This PR changes that behavior so now the appropriate return status code is output and GH can respond accordingly.

This may very well help prevent many "gotchas" in the future.
